### PR TITLE
fixed syntax error in schema

### DIFF
--- a/server/schema.sql
+++ b/server/schema.sql
@@ -13,4 +13,4 @@
 DROP TABLE IF EXISTS users;
 
 --Serial is used to auto-increment (75% sure on this...)
-CREATE TABLE users id SERIAL PRIMARY KEY, name VARCHAR, age INTEGER DEFAULT null);
+CREATE TABLE users (id SERIAL PRIMARY KEY, name VARCHAR, age INTEGER DEFAULT null);


### PR DESCRIPTION
Added a parentheses. 
Now if you run psql < schema.sql it will run the schema file and drop/create tables.
